### PR TITLE
[fix]: [DBOPS-349]: handle '=' in encoded drone output

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -58,5 +58,7 @@ echo "/liquibase/liquibase $argument_string"
 
 encoded_command_logs=$(cat command_logs.txt | base64 -w 0)
 
+encoded_command_logs=`echo $encoded_command_logs | tr = -`
+
 echo "encoded_command_logs=$encoded_command_logs" > "$DRONE_OUTPUT"
 


### PR DESCRIPTION
godotenv uses '=' as the separator and we are using it for parsing key-value pair of drone ouput. Replacing '=' with '-' in base64 encoded string to avoid above.