### PR TITLE
feat: [DBOPS-1028]: use client.key and client.crt to generate pkcs12

### DIFF
--- a/docker/Dockerfile.linux-mongo.amd64
+++ b/docker/Dockerfile.linux-mongo.amd64
@@ -1,5 +1,5 @@
 FROM alpine:3.17 as alpine
-RUN apk add -U --no-cache ca-certificates
+RUN apk add -U --no-cache ca-certificates openssl
 
 ENV MONGO_DRIVER_CORE_VERSION=5.0.0
 ENV MONGO_DRIVER_SYNC_VERSION=5.0.0
@@ -25,6 +25,11 @@ FROM liquibase/liquibase:4.27-alpine
 ADD resources /resources
 COPY entrypoint.sh /entrypoint.sh
 RUN lpm add mysql --global
+
+# Copy OpenSSL
+COPY --from=alpine /usr/bin/openssl /usr/bin/openssl
+COPY --from=alpine /lib/libssl.so.3 /lib/libssl.so.3
+COPY --from=alpine /lib/libcrypto.so.3 /lib/libcrypto.so.3
 
 
 COPY --from=alpine /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/

--- a/docker/Dockerfile.linux-mongo.arm64
+++ b/docker/Dockerfile.linux-mongo.arm64
@@ -1,5 +1,5 @@
 FROM alpine:3.17 as alpine
-RUN apk add -U --no-cache ca-certificates
+RUN apk add -U --no-cache ca-certificates openssl
 
 ENV MONGO_DRIVER_CORE_VERSION=5.0.0
 ENV MONGO_DRIVER_SYNC_VERSION=5.0.0
@@ -25,6 +25,11 @@ FROM liquibase/liquibase:4.27-alpine
 ADD resources /resources
 COPY entrypoint.sh /entrypoint.sh
 RUN lpm add mysql --global
+
+# Copy OpenSSL
+COPY --from=alpine /usr/bin/openssl /usr/bin/openssl
+COPY --from=alpine /lib/libssl.so.3 /lib/libssl.so.3
+COPY --from=alpine /lib/libcrypto.so.3 /lib/libcrypto.so.3
 
 
 COPY --from=alpine /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/

--- a/docker/Dockerfile.linux-spanner.amd64
+++ b/docker/Dockerfile.linux-spanner.amd64
@@ -1,5 +1,5 @@
 FROM alpine:3.17 AS alpine
-RUN apk add -U --no-cache ca-certificates
+RUN apk add -U --no-cache ca-certificates openssl
 
 ENV LIQUIBASE_SPANNER_VERSION=4.30.0.1
 
@@ -12,6 +12,11 @@ FROM liquibase/liquibase:4.27-alpine
 ADD resources /resources
 COPY entrypoint.sh /entrypoint.sh
 RUN lpm add mysql --global
+
+# Copy OpenSSL
+COPY --from=alpine /usr/bin/openssl /usr/bin/openssl
+COPY --from=alpine /lib/libssl.so.3 /lib/libssl.so.3
+COPY --from=alpine /lib/libcrypto.so.3 /lib/libcrypto.so.3
 
 
 COPY --from=alpine /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/

--- a/docker/Dockerfile.linux-spanner.arm64
+++ b/docker/Dockerfile.linux-spanner.arm64
@@ -1,5 +1,5 @@
 FROM alpine:3.17 AS alpine
-RUN apk add -U --no-cache ca-certificates
+RUN apk add -U --no-cache ca-certificates openssl
 
 ENV LIQUIBASE_SPANNER_VERSION=4.30.0.1
 
@@ -12,6 +12,11 @@ FROM liquibase/liquibase:4.27-alpine
 ADD resources /resources
 COPY entrypoint.sh /entrypoint.sh
 RUN lpm add mysql --global
+
+# Copy OpenSSL
+COPY --from=alpine /usr/bin/openssl /usr/bin/openssl
+COPY --from=alpine /lib/libssl.so.3 /lib/libssl.so.3
+COPY --from=alpine /lib/libcrypto.so.3 /lib/libcrypto.so.3
 
 
 COPY --from=alpine /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/

--- a/docker/Dockerfile.linux.amd64
+++ b/docker/Dockerfile.linux.amd64
@@ -1,10 +1,15 @@
 FROM alpine:3.17 as alpine
-RUN apk add -U --no-cache ca-certificates
+RUN apk add -U --no-cache ca-certificates openssl
 
 FROM liquibase/liquibase:4.27-alpine
 ADD resources /resources
 COPY entrypoint.sh /entrypoint.sh
 RUN lpm add mysql --global
+
+# Copy OpenSSL
+COPY --from=alpine /usr/bin/openssl /usr/bin/openssl
+COPY --from=alpine /lib/libssl.so.3 /lib/libssl.so.3
+COPY --from=alpine /lib/libcrypto.so.3 /lib/libcrypto.so.3
 
 COPY --from=alpine /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/Dockerfile.linux.arm64
+++ b/docker/Dockerfile.linux.arm64
@@ -1,10 +1,15 @@
 FROM alpine:3.17 as alpine
-RUN apk add -U --no-cache ca-certificates
+RUN apk add -U --no-cache ca-certificates openssl
 
 FROM liquibase/liquibase:4.27-alpine
 ADD resources /resources
 COPY entrypoint.sh /entrypoint.sh
 RUN lpm add mysql --global
+
+# Copy OpenSSL
+COPY --from=alpine /usr/bin/openssl /usr/bin/openssl
+COPY --from=alpine /lib/libssl.so.3 /lib/libssl.so.3
+COPY --from=alpine /lib/libcrypto.so.3 /lib/libcrypto.so.3
 
 COPY --from=alpine /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Update the drone plugin liquibase image to use the client.key and client.crt files to generate the pkcs12 file and upload it to keystore.

<img width="1196" alt="Screenshot 2025-03-12 at 5 04 29 PM" src="https://github.com/user-attachments/assets/34ac08b4-f411-416c-adf0-377d25b09d91" />


