### PR TITLE
feat: [DBOPS-1099]: Added SKIP_SEND_ENCODED_LOGS and STEP_OUTPUT_FILE

### DIFF
--- a/docker/Dockerfile.linux-mongo.amd64
+++ b/docker/Dockerfile.linux-mongo.amd64
@@ -9,6 +9,8 @@ ENV MONGO_DRIVER_SYNC_VERSION=5.0.0
 ENV BSON_VERSION=5.0.0
 ENV LIQUIBASE_MONGODB_VERSION=4.24.0
 ENV SNAKE_YAML_VERSION=2.2
+ENV LIQUIBASE_DBOPS_EXT_VERSION=1.3.0
+ENV LIQUIBASE_DBOPS_EXT_ZSTD_VERSION=1.5.5-5
 
 RUN apk add --no-cache wget && \
     mkdir -p /liquibase/lib && \
@@ -21,7 +23,11 @@ RUN apk add --no-cache wget && \
     wget -O /liquibase/lib/liquibase-mongodb-${LIQUIBASE_MONGODB_VERSION}.jar \
     https://repo1.maven.org/maven2/org/liquibase/ext/liquibase-mongodb/${LIQUIBASE_MONGODB_VERSION}/liquibase-mongodb-${LIQUIBASE_MONGODB_VERSION}.jar && \
     wget -O /liquibase/lib/snakeyaml-${SNAKE_YAML_VERSION}.jar \
-    https://repo1.maven.org/maven2/org/yaml/snakeyaml/${SNAKE_YAML_VERSION}/snakeyaml-${SNAKE_YAML_VERSION}.jar
+    https://repo1.maven.org/maven2/org/yaml/snakeyaml/${SNAKE_YAML_VERSION}/snakeyaml-${SNAKE_YAML_VERSION}.jar && \
+    wget -O /liquibase/lib/dbops-extensions-${LIQUIBASE_DBOPS_EXT_VERSION}.jar \
+    https://us-maven.pkg.dev/gar-prod-setup/harness-maven-public/io/harness/dbops-extensions/${LIQUIBASE_DBOPS_EXT_VERSION}/dbops-extensions-${LIQUIBASE_DBOPS_EXT_VERSION}.jar && \
+    wget -O /liquibase/lib/zstd-jni-${LIQUIBASE_DBOPS_EXT_ZSTD_VERSION}.jar \
+    https://repo1.maven.org/maven2/com/github/luben/zstd-jni/${LIQUIBASE_DBOPS_EXT_ZSTD_VERSION}/zstd-jni-${LIQUIBASE_DBOPS_EXT_ZSTD_VERSION}.jar
 
 
 FROM liquibase/liquibase:4.27-alpine

--- a/docker/Dockerfile.linux-mongo.arm64
+++ b/docker/Dockerfile.linux-mongo.arm64
@@ -9,6 +9,8 @@ ENV MONGO_DRIVER_SYNC_VERSION=5.0.0
 ENV BSON_VERSION=5.0.0
 ENV LIQUIBASE_MONGODB_VERSION=4.24.0
 ENV SNAKE_YAML_VERSION=2.2
+ENV LIQUIBASE_DBOPS_EXT_VERSION=1.3.0
+ENV LIQUIBASE_DBOPS_EXT_ZSTD_VERSION=1.5.5-5
 
 RUN apk add --no-cache wget && \
     mkdir -p /liquibase/lib && \
@@ -21,7 +23,13 @@ RUN apk add --no-cache wget && \
     wget -O /liquibase/lib/liquibase-mongodb-${LIQUIBASE_MONGODB_VERSION}.jar \
     https://repo1.maven.org/maven2/org/liquibase/ext/liquibase-mongodb/${LIQUIBASE_MONGODB_VERSION}/liquibase-mongodb-${LIQUIBASE_MONGODB_VERSION}.jar && \
     wget -O /liquibase/lib/snakeyaml-${SNAKE_YAML_VERSION}.jar \
-    https://repo1.maven.org/maven2/org/yaml/snakeyaml/${SNAKE_YAML_VERSION}/snakeyaml-${SNAKE_YAML_VERSION}.jar
+    https://repo1.maven.org/maven2/org/yaml/snakeyaml/${SNAKE_YAML_VERSION}/snakeyaml-${SNAKE_YAML_VERSION}.jar && \
+    wget -O /liquibase/lib/dbops-extensions-${LIQUIBASE_DBOPS_EXT_VERSION}.jar \
+    https://us-maven.pkg.dev/gar-prod-setup/harness-maven-public/io/harness/dbops-extensions/${LIQUIBASE_DBOPS_EXT_VERSION}/dbops-extensions-${LIQUIBASE_DBOPS_EXT_VERSION}.jar && \
+    wget -O /liquibase/lib/zstd-jni-${LIQUIBASE_DBOPS_EXT_ZSTD_VERSION}.jar \
+    https://repo1.maven.org/maven2/com/github/luben/zstd-jni/${LIQUIBASE_DBOPS_EXT_ZSTD_VERSION}/zstd-jni-${LIQUIBASE_DBOPS_EXT_ZSTD_VERSION}.jar
+
+
 
 
 FROM liquibase/liquibase:4.27-alpine

--- a/docker/Dockerfile.linux-spanner.amd64
+++ b/docker/Dockerfile.linux-spanner.amd64
@@ -5,11 +5,17 @@ RUN apk add -U --no-cache ca-certificates openssl jq=1.6-r2 oniguruma=6.9.8-r0
 RUN apk add --no-cache zstd=1.5.5-r0
 
 ENV LIQUIBASE_SPANNER_VERSION=4.30.0.1
+ENV LIQUIBASE_DBOPS_EXT_VERSION=1.3.0
+ENV LIQUIBASE_DBOPS_EXT_ZSTD_VERSION=1.5.5-5
 
 RUN apk add --no-cache wget && \
     mkdir -p /liquibase/lib && \
     wget -O /liquibase/lib/liquibase-spanner-${LIQUIBASE_SPANNER_VERSION}-all.jar \
-    https://github.com/cloudspannerecosystem/liquibase-spanner/releases/download/${LIQUIBASE_SPANNER_VERSION}/liquibase-spanner-${LIQUIBASE_SPANNER_VERSION}-all.jar
+    https://github.com/cloudspannerecosystem/liquibase-spanner/releases/download/${LIQUIBASE_SPANNER_VERSION}/liquibase-spanner-${LIQUIBASE_SPANNER_VERSION}-all.jar && \
+    wget -O /liquibase/lib/dbops-extensions-${LIQUIBASE_DBOPS_EXT_VERSION}.jar \
+    https://us-maven.pkg.dev/gar-prod-setup/harness-maven-public/io/harness/dbops-extensions/${LIQUIBASE_DBOPS_EXT_VERSION}/dbops-extensions-${LIQUIBASE_DBOPS_EXT_VERSION}.jar && \
+    wget -O /liquibase/lib/zstd-jni-${LIQUIBASE_DBOPS_EXT_ZSTD_VERSION}.jar \
+    https://repo1.maven.org/maven2/com/github/luben/zstd-jni/${LIQUIBASE_DBOPS_EXT_ZSTD_VERSION}/zstd-jni-${LIQUIBASE_DBOPS_EXT_ZSTD_VERSION}.jar
 
 FROM liquibase/liquibase:4.27-alpine
 ADD resources /resources

--- a/docker/Dockerfile.linux-spanner.arm64
+++ b/docker/Dockerfile.linux-spanner.arm64
@@ -5,11 +5,17 @@ RUN apk add -U --no-cache ca-certificates openssl jq=1.6-r2 oniguruma=6.9.8-r0
 RUN apk add --no-cache zstd=1.5.5-r0
 
 ENV LIQUIBASE_SPANNER_VERSION=4.30.0.1
+ENV LIQUIBASE_DBOPS_EXT_VERSION=1.3.0
+ENV LIQUIBASE_DBOPS_EXT_ZSTD_VERSION=1.5.5-5
 
 RUN apk add --no-cache wget && \
     mkdir -p /liquibase/lib && \
     wget -O /liquibase/lib/liquibase-spanner-${LIQUIBASE_SPANNER_VERSION}-all.jar \
-    https://github.com/cloudspannerecosystem/liquibase-spanner/releases/download/${LIQUIBASE_SPANNER_VERSION}/liquibase-spanner-${LIQUIBASE_SPANNER_VERSION}-all.jar
+    https://github.com/cloudspannerecosystem/liquibase-spanner/releases/download/${LIQUIBASE_SPANNER_VERSION}/liquibase-spanner-${LIQUIBASE_SPANNER_VERSION}-all.jar && \
+    wget -O /liquibase/lib/dbops-extensions-${LIQUIBASE_DBOPS_EXT_VERSION}.jar \
+    https://us-maven.pkg.dev/gar-prod-setup/harness-maven-public/io/harness/dbops-extensions/${LIQUIBASE_DBOPS_EXT_VERSION}/dbops-extensions-${LIQUIBASE_DBOPS_EXT_VERSION}.jar && \
+    wget -O /liquibase/lib/zstd-jni-${LIQUIBASE_DBOPS_EXT_ZSTD_VERSION}.jar \
+    https://repo1.maven.org/maven2/com/github/luben/zstd-jni/${LIQUIBASE_DBOPS_EXT_ZSTD_VERSION}/zstd-jni-${LIQUIBASE_DBOPS_EXT_ZSTD_VERSION}.jar
 
 FROM liquibase/liquibase:4.27-alpine
 ADD resources /resources

--- a/docker/Dockerfile.linux.amd64
+++ b/docker/Dockerfile.linux.amd64
@@ -4,6 +4,15 @@ RUN apk add -U --no-cache ca-certificates openssl jq=1.6-r2 oniguruma=6.9.8-r0
 # Install zstd
 RUN apk add --no-cache zstd=1.5.5-r0
 
+ENV LIQUIBASE_DBOPS_EXT_VERSION=1.3.0
+ENV LIQUIBASE_DBOPS_EXT_ZSTD_VERSION=1.5.5-5
+
+RUN mkdir -p /liquibase/lib && \
+    wget -O /liquibase/lib/dbops-extensions-${LIQUIBASE_DBOPS_EXT_VERSION}.jar \
+    https://us-maven.pkg.dev/gar-prod-setup/harness-maven-public/io/harness/dbops-extensions/${LIQUIBASE_DBOPS_EXT_VERSION}/dbops-extensions-${LIQUIBASE_DBOPS_EXT_VERSION}.jar && \
+    wget -O /liquibase/lib/zstd-jni-${LIQUIBASE_DBOPS_EXT_ZSTD_VERSION}.jar \
+    https://repo1.maven.org/maven2/com/github/luben/zstd-jni/${LIQUIBASE_DBOPS_EXT_ZSTD_VERSION}/zstd-jni-${LIQUIBASE_DBOPS_EXT_ZSTD_VERSION}.jar
+
 FROM liquibase/liquibase:4.27-alpine
 ADD resources /resources
 COPY entrypoint.sh /entrypoint.sh
@@ -15,11 +24,13 @@ COPY --from=alpine /lib/libssl.so.3 /lib/libssl.so.3
 COPY --from=alpine /lib/libcrypto.so.3 /lib/libcrypto.so.3
 
 COPY --from=alpine /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+
 # Copy the zstd binary from Alpine stage
 COPY --from=alpine /usr/bin/zstd /usr/bin/zstd
 # Copy jq dependencies
 COPY --from=alpine /usr/bin/jq /usr/bin/jq
 COPY --from=alpine /usr/lib/libonig.so.5 /usr/lib/libonig.so.5
 
+COPY --from=alpine /liquibase/lib /liquibase/lib
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["--help"]

--- a/docker/Dockerfile.linux.arm64
+++ b/docker/Dockerfile.linux.arm64
@@ -4,6 +4,15 @@ RUN apk add -U --no-cache ca-certificates openssl jq=1.6-r2 oniguruma=6.9.8-r0
 # Install zstd
 RUN apk add --no-cache zstd=1.5.5-r0
 
+ENV LIQUIBASE_DBOPS_EXT_VERSION=1.3.0
+ENV LIQUIBASE_DBOPS_EXT_ZSTD_VERSION=1.5.5-5
+
+RUN mkdir -p /liquibase/lib && \
+    wget -O /liquibase/lib/dbops-extensions-${LIQUIBASE_DBOPS_EXT_VERSION}.jar \
+    https://us-maven.pkg.dev/gar-prod-setup/harness-maven-public/io/harness/dbops-extensions/${LIQUIBASE_DBOPS_EXT_VERSION}/dbops-extensions-${LIQUIBASE_DBOPS_EXT_VERSION}.jar && \
+    wget -O /liquibase/lib/zstd-jni-${LIQUIBASE_DBOPS_EXT_ZSTD_VERSION}.jar \
+    https://repo1.maven.org/maven2/com/github/luben/zstd-jni/${LIQUIBASE_DBOPS_EXT_ZSTD_VERSION}/zstd-jni-${LIQUIBASE_DBOPS_EXT_ZSTD_VERSION}.jar
+
 FROM liquibase/liquibase:4.27-alpine
 ADD resources /resources
 COPY entrypoint.sh /entrypoint.sh
@@ -20,6 +29,6 @@ COPY --from=alpine /usr/bin/zstd /usr/bin/zstd
 # Copy jq dependencies
 COPY --from=alpine /usr/bin/jq /usr/bin/jq
 COPY --from=alpine /usr/lib/libonig.so.5 /usr/lib/libonig.so.5
-
+COPY --from=alpine /liquibase/lib /liquibase/lib
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["--help"]


### PR DESCRIPTION
* Added a flag SKIP_SEND_ENCODED_LOGS to send encoded_command_logs as part of the drone output
* added STEP_OUTPUT_FILE which reads the each line and adds to the drone output

## Pull Request Summary: feat/DBOPS-1099

This pull request introduces enhancements to the Dockerfiles and the entrypoint script to support new environment variables and functionalities related to logging and output management.

### Key Changes:
- **New Environment Variables**: Added `LIQUIBASE_DBOPS_EXT_VERSION` and `LIQUIBASE_DBOPS_EXT_ZSTD_VERSION` to manage dependencies for Liquibase DB operations.
- **Dependency Management**: Updated Dockerfiles to include the downloading of new JAR files for DB operations and Zstandard compression.
- **Logging Control**: Modified the entrypoint script to conditionally skip sending encoded logs based on the `SKIP_SEND_ENCODED_LOGS` environment variable. Additionally, it now captures and outputs the contents of a step output JSON file if it exists.

These changes enhance the flexibility and functionality of the Docker images, particularly in the context of database operations and logging behavior.