### PR TITLE
feat: [DBOPS-1306]: Added common library download scripts

### DIFF
--- a/docker/Dockerfile.linux-mongo.amd64
+++ b/docker/Dockerfile.linux-mongo.amd64
@@ -4,30 +4,13 @@ RUN apk add -U --no-cache ca-certificates openssl jq=1.6-r2 oniguruma=6.9.8-r0
 # Install zstd
 RUN apk add --no-cache zstd=1.5.5-r0
 
-ENV MONGO_DRIVER_CORE_VERSION=5.0.0
-ENV MONGO_DRIVER_SYNC_VERSION=5.0.0
-ENV BSON_VERSION=5.0.0
-ENV LIQUIBASE_MONGODB_VERSION=4.24.0
-ENV SNAKE_YAML_VERSION=2.2
-ENV LIQUIBASE_DBOPS_EXT_VERSION=1.8.0
-ENV LIQUIBASE_DBOPS_EXT_ZSTD_VERSION=1.5.5-5
+COPY scripts/download-common.sh /scripts/download-common.sh
+RUN chmod +x /scripts/download-common.sh
+COPY scripts/download-mongo.sh /scripts/download-mongo.sh
+RUN chmod +x /scripts/download-mongo.sh
 
-RUN apk add --no-cache wget && \
-    mkdir -p /liquibase/lib && \
-    wget -O /liquibase/lib/mongodb-driver-core-${MONGO_DRIVER_CORE_VERSION}.jar \
-    https://repo1.maven.org/maven2/org/mongodb/mongodb-driver-core/${MONGO_DRIVER_CORE_VERSION}/mongodb-driver-core-${MONGO_DRIVER_CORE_VERSION}.jar && \
-    wget -O /liquibase/lib/mongodb-driver-sync-${MONGO_DRIVER_SYNC_VERSION}.jar \
-    https://repo1.maven.org/maven2/org/mongodb/mongodb-driver-sync/${MONGO_DRIVER_SYNC_VERSION}/mongodb-driver-sync-${MONGO_DRIVER_SYNC_VERSION}.jar && \
-    wget -O /liquibase/lib/bson-${BSON_VERSION}.jar \
-    https://repo1.maven.org/maven2/org/mongodb/bson/${BSON_VERSION}/bson-${BSON_VERSION}.jar && \
-    wget -O /liquibase/lib/liquibase-mongodb-${LIQUIBASE_MONGODB_VERSION}.jar \
-    https://repo1.maven.org/maven2/org/liquibase/ext/liquibase-mongodb/${LIQUIBASE_MONGODB_VERSION}/liquibase-mongodb-${LIQUIBASE_MONGODB_VERSION}.jar && \
-    wget -O /liquibase/lib/snakeyaml-${SNAKE_YAML_VERSION}.jar \
-    https://repo1.maven.org/maven2/org/yaml/snakeyaml/${SNAKE_YAML_VERSION}/snakeyaml-${SNAKE_YAML_VERSION}.jar && \
-    wget -O /liquibase/lib/dbops-extensions-${LIQUIBASE_DBOPS_EXT_VERSION}.jar \
-    https://us-maven.pkg.dev/gar-prod-setup/harness-maven-public/io/harness/dbops-extensions/${LIQUIBASE_DBOPS_EXT_VERSION}/dbops-extensions-${LIQUIBASE_DBOPS_EXT_VERSION}.jar && \
-    wget -O /liquibase/lib/zstd-jni-${LIQUIBASE_DBOPS_EXT_ZSTD_VERSION}.jar \
-    https://repo1.maven.org/maven2/com/github/luben/zstd-jni/${LIQUIBASE_DBOPS_EXT_ZSTD_VERSION}/zstd-jni-${LIQUIBASE_DBOPS_EXT_ZSTD_VERSION}.jar
+RUN /scripts/download-common.sh \
+ && /scripts/download-mongo.sh
 
 
 FROM liquibase/liquibase:4.27-alpine

--- a/docker/Dockerfile.linux-mongo.arm64
+++ b/docker/Dockerfile.linux-mongo.arm64
@@ -4,33 +4,13 @@ RUN apk add -U --no-cache ca-certificates openssl jq=1.6-r2 oniguruma=6.9.8-r0
 # Install zstd
 RUN apk add --no-cache zstd=1.5.5-r0
 
-ENV MONGO_DRIVER_CORE_VERSION=5.0.0
-ENV MONGO_DRIVER_SYNC_VERSION=5.0.0
-ENV BSON_VERSION=5.0.0
-ENV LIQUIBASE_MONGODB_VERSION=4.24.0
-ENV SNAKE_YAML_VERSION=2.2
-ENV LIQUIBASE_DBOPS_EXT_VERSION=1.8.0
-ENV LIQUIBASE_DBOPS_EXT_ZSTD_VERSION=1.5.5-5
+COPY scripts/download-common.sh /scripts/download-common.sh
+RUN chmod +x /scripts/download-common.sh
+COPY scripts/download-mongo.sh /scripts/download-mongo.sh
+RUN chmod +x /scripts/download-mongo.sh
 
-RUN apk add --no-cache wget && \
-    mkdir -p /liquibase/lib && \
-    wget -O /liquibase/lib/mongodb-driver-core-${MONGO_DRIVER_CORE_VERSION}.jar \
-    https://repo1.maven.org/maven2/org/mongodb/mongodb-driver-core/${MONGO_DRIVER_CORE_VERSION}/mongodb-driver-core-${MONGO_DRIVER_CORE_VERSION}.jar && \
-    wget -O /liquibase/lib/mongodb-driver-sync-${MONGO_DRIVER_SYNC_VERSION}.jar \
-    https://repo1.maven.org/maven2/org/mongodb/mongodb-driver-sync/${MONGO_DRIVER_SYNC_VERSION}/mongodb-driver-sync-${MONGO_DRIVER_SYNC_VERSION}.jar && \
-    wget -O /liquibase/lib/bson-${BSON_VERSION}.jar \
-    https://repo1.maven.org/maven2/org/mongodb/bson/${BSON_VERSION}/bson-${BSON_VERSION}.jar && \
-    wget -O /liquibase/lib/liquibase-mongodb-${LIQUIBASE_MONGODB_VERSION}.jar \
-    https://repo1.maven.org/maven2/org/liquibase/ext/liquibase-mongodb/${LIQUIBASE_MONGODB_VERSION}/liquibase-mongodb-${LIQUIBASE_MONGODB_VERSION}.jar && \
-    wget -O /liquibase/lib/snakeyaml-${SNAKE_YAML_VERSION}.jar \
-    https://repo1.maven.org/maven2/org/yaml/snakeyaml/${SNAKE_YAML_VERSION}/snakeyaml-${SNAKE_YAML_VERSION}.jar && \
-    wget -O /liquibase/lib/dbops-extensions-${LIQUIBASE_DBOPS_EXT_VERSION}.jar \
-    https://us-maven.pkg.dev/gar-prod-setup/harness-maven-public/io/harness/dbops-extensions/${LIQUIBASE_DBOPS_EXT_VERSION}/dbops-extensions-${LIQUIBASE_DBOPS_EXT_VERSION}.jar && \
-    wget -O /liquibase/lib/zstd-jni-${LIQUIBASE_DBOPS_EXT_ZSTD_VERSION}.jar \
-    https://repo1.maven.org/maven2/com/github/luben/zstd-jni/${LIQUIBASE_DBOPS_EXT_ZSTD_VERSION}/zstd-jni-${LIQUIBASE_DBOPS_EXT_ZSTD_VERSION}.jar
-
-
-
+RUN /scripts/download-common.sh \
+ && /scripts/download-mongo.sh
 
 FROM liquibase/liquibase:4.27-alpine
 ADD resources /resources

--- a/docker/Dockerfile.linux-spanner.amd64
+++ b/docker/Dockerfile.linux-spanner.amd64
@@ -4,18 +4,13 @@ RUN apk add -U --no-cache ca-certificates openssl jq=1.6-r2 oniguruma=6.9.8-r0
 # Install zstd
 RUN apk add --no-cache zstd=1.5.5-r0
 
-ENV LIQUIBASE_SPANNER_VERSION=4.30.0.1
-ENV LIQUIBASE_DBOPS_EXT_VERSION=1.8.0
-ENV LIQUIBASE_DBOPS_EXT_ZSTD_VERSION=1.5.5-5
+COPY scripts/download-common.sh /scripts/download-common.sh
+RUN chmod +x /scripts/download-common.sh
+COPY scripts/download-spanner.sh /scripts/download-spanner.sh
+RUN chmod +x /scripts/download-spanner.sh
 
-RUN apk add --no-cache wget && \
-    mkdir -p /liquibase/lib && \
-    wget -O /liquibase/lib/liquibase-spanner-${LIQUIBASE_SPANNER_VERSION}-all.jar \
-    https://github.com/cloudspannerecosystem/liquibase-spanner/releases/download/${LIQUIBASE_SPANNER_VERSION}/liquibase-spanner-${LIQUIBASE_SPANNER_VERSION}-all.jar && \
-    wget -O /liquibase/lib/dbops-extensions-${LIQUIBASE_DBOPS_EXT_VERSION}.jar \
-    https://us-maven.pkg.dev/gar-prod-setup/harness-maven-public/io/harness/dbops-extensions/${LIQUIBASE_DBOPS_EXT_VERSION}/dbops-extensions-${LIQUIBASE_DBOPS_EXT_VERSION}.jar && \
-    wget -O /liquibase/lib/zstd-jni-${LIQUIBASE_DBOPS_EXT_ZSTD_VERSION}.jar \
-    https://repo1.maven.org/maven2/com/github/luben/zstd-jni/${LIQUIBASE_DBOPS_EXT_ZSTD_VERSION}/zstd-jni-${LIQUIBASE_DBOPS_EXT_ZSTD_VERSION}.jar
+RUN /scripts/download-common.sh \
+ && /scripts/download-spanner.sh
 
 FROM liquibase/liquibase:4.27-alpine
 ADD resources /resources

--- a/docker/Dockerfile.linux-spanner.arm64
+++ b/docker/Dockerfile.linux-spanner.arm64
@@ -4,18 +4,13 @@ RUN apk add -U --no-cache ca-certificates openssl jq=1.6-r2 oniguruma=6.9.8-r0
 # Install zstd
 RUN apk add --no-cache zstd=1.5.5-r0
 
-ENV LIQUIBASE_SPANNER_VERSION=4.30.0.1
-ENV LIQUIBASE_DBOPS_EXT_VERSION=1.8.0
-ENV LIQUIBASE_DBOPS_EXT_ZSTD_VERSION=1.5.5-5
+COPY scripts/download-common.sh /scripts/download-common.sh
+RUN chmod +x /scripts/download-common.sh
+COPY scripts/download-spanner.sh /scripts/download-spanner.sh
+RUN chmod +x /scripts/download-spanner.sh
 
-RUN apk add --no-cache wget && \
-    mkdir -p /liquibase/lib && \
-    wget -O /liquibase/lib/liquibase-spanner-${LIQUIBASE_SPANNER_VERSION}-all.jar \
-    https://github.com/cloudspannerecosystem/liquibase-spanner/releases/download/${LIQUIBASE_SPANNER_VERSION}/liquibase-spanner-${LIQUIBASE_SPANNER_VERSION}-all.jar && \
-    wget -O /liquibase/lib/dbops-extensions-${LIQUIBASE_DBOPS_EXT_VERSION}.jar \
-    https://us-maven.pkg.dev/gar-prod-setup/harness-maven-public/io/harness/dbops-extensions/${LIQUIBASE_DBOPS_EXT_VERSION}/dbops-extensions-${LIQUIBASE_DBOPS_EXT_VERSION}.jar && \
-    wget -O /liquibase/lib/zstd-jni-${LIQUIBASE_DBOPS_EXT_ZSTD_VERSION}.jar \
-    https://repo1.maven.org/maven2/com/github/luben/zstd-jni/${LIQUIBASE_DBOPS_EXT_ZSTD_VERSION}/zstd-jni-${LIQUIBASE_DBOPS_EXT_ZSTD_VERSION}.jar
+RUN /scripts/download-common.sh \
+ && /scripts/download-spanner.sh
 
 FROM liquibase/liquibase:4.27-alpine
 ADD resources /resources

--- a/docker/Dockerfile.linux.amd64
+++ b/docker/Dockerfile.linux.amd64
@@ -4,14 +4,9 @@ RUN apk add -U --no-cache ca-certificates openssl jq=1.6-r2 oniguruma=6.9.8-r0
 # Install zstd
 RUN apk add --no-cache zstd=1.5.5-r0
 
-ENV LIQUIBASE_DBOPS_EXT_VERSION=1.8.0
-ENV LIQUIBASE_DBOPS_EXT_ZSTD_VERSION=1.5.5-5
-
-RUN mkdir -p /liquibase/lib && \
-    wget -O /liquibase/lib/dbops-extensions-${LIQUIBASE_DBOPS_EXT_VERSION}.jar \
-    https://us-maven.pkg.dev/gar-prod-setup/harness-maven-public/io/harness/dbops-extensions/${LIQUIBASE_DBOPS_EXT_VERSION}/dbops-extensions-${LIQUIBASE_DBOPS_EXT_VERSION}.jar && \
-    wget -O /liquibase/lib/zstd-jni-${LIQUIBASE_DBOPS_EXT_ZSTD_VERSION}.jar \
-    https://repo1.maven.org/maven2/com/github/luben/zstd-jni/${LIQUIBASE_DBOPS_EXT_ZSTD_VERSION}/zstd-jni-${LIQUIBASE_DBOPS_EXT_ZSTD_VERSION}.jar
+COPY scripts/download-common.sh /scripts/download-common.sh
+RUN chmod +x /scripts/download-common.sh
+RUN /scripts/download-common.sh
 
 FROM liquibase/liquibase:4.27-alpine
 ADD resources /resources

--- a/docker/Dockerfile.linux.arm64
+++ b/docker/Dockerfile.linux.arm64
@@ -4,14 +4,9 @@ RUN apk add -U --no-cache ca-certificates openssl jq=1.6-r2 oniguruma=6.9.8-r0
 # Install zstd
 RUN apk add --no-cache zstd=1.5.5-r0
 
-ENV LIQUIBASE_DBOPS_EXT_VERSION=1.8.0
-ENV LIQUIBASE_DBOPS_EXT_ZSTD_VERSION=1.5.5-5
-
-RUN mkdir -p /liquibase/lib && \
-    wget -O /liquibase/lib/dbops-extensions-${LIQUIBASE_DBOPS_EXT_VERSION}.jar \
-    https://us-maven.pkg.dev/gar-prod-setup/harness-maven-public/io/harness/dbops-extensions/${LIQUIBASE_DBOPS_EXT_VERSION}/dbops-extensions-${LIQUIBASE_DBOPS_EXT_VERSION}.jar && \
-    wget -O /liquibase/lib/zstd-jni-${LIQUIBASE_DBOPS_EXT_ZSTD_VERSION}.jar \
-    https://repo1.maven.org/maven2/com/github/luben/zstd-jni/${LIQUIBASE_DBOPS_EXT_ZSTD_VERSION}/zstd-jni-${LIQUIBASE_DBOPS_EXT_ZSTD_VERSION}.jar
+COPY scripts/download-common.sh /scripts/download-common.sh
+RUN chmod +x /scripts/download-common.sh
+RUN /scripts/download-common.sh
 
 FROM liquibase/liquibase:4.27-alpine
 ADD resources /resources

--- a/scripts/download-common.sh
+++ b/scripts/download-common.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env sh
+set -eux
+
+LIQUIBASE_DBOPS_EXT_VERSION="1.9.0"
+LIQUIBASE_DBOPS_EXT_ZSTD_VERSION="1.5.5-5"
+OKIO_VERSION="3.2.0"
+OKHTTP_VERSION="4.11.0"
+LOGGING_INTERCEPTOR_VERSION="4.11.0"
+RETROFIT_VERSION="3.0.0"
+CONVERTOR_GSON_VERSION="3.0.0"
+GSON_VERSION="2.13.1"
+KOTLIN_STLIB_VERSION="2.1.21"
+
+
+mkdir -p /liquibase/lib
+
+# Core dbops extension jars
+wget -O /liquibase/lib/dbops-extensions-${LIQUIBASE_DBOPS_EXT_VERSION}.jar \
+  "https://us-maven.pkg.dev/gar-prod-setup/harness-maven-public/io/harness/dbops-extensions/${LIQUIBASE_DBOPS_EXT_VERSION}/dbops-extensions-${LIQUIBASE_DBOPS_EXT_VERSION}.jar"
+
+# zstd-jni jar
+wget -O /liquibase/lib/zstd-jni-${LIQUIBASE_DBOPS_EXT_ZSTD_VERSION}.jar \
+  "https://repo1.maven.org/maven2/com/github/luben/zstd-jni/${LIQUIBASE_DBOPS_EXT_ZSTD_VERSION}/zstd-jni-${LIQUIBASE_DBOPS_EXT_ZSTD_VERSION}.jar"
+
+# okio & okio-jvm
+wget -O /liquibase/lib/okio-${OKIO_VERSION}.jar \
+  "https://repo1.maven.org/maven2/com/squareup/okio/okio/${OKIO_VERSION}/okio-${OKIO_VERSION}.jar"
+wget -O /liquibase/lib/okio-jvm-${OKIO_VERSION}.jar \
+  "https://repo1.maven.org/maven2/com/squareup/okio/okio-jvm/${OKIO_VERSION}/okio-jvm-${OKIO_VERSION}.jar"
+
+# okhttp & logging-interceptor
+wget -O /liquibase/lib/okhttp-${OKHTTP_VERSION}.jar \
+  "https://repo1.maven.org/maven2/com/squareup/okhttp3/okhttp/${OKHTTP_VERSION}/okhttp-${OKHTTP_VERSION}.jar"
+wget -O /liquibase/lib/logging-interceptor-${LOGGING_INTERCEPTOR_VERSION}.jar \
+  "https://repo1.maven.org/maven2/com/squareup/okhttp3/logging-interceptor/${LOGGING_INTERCEPTOR_VERSION}/logging-interceptor-${LOGGING_INTERCEPTOR_VERSION}.jar"
+
+# retrofit & converter-gson & gson & kotlin-stdlib
+wget -O /liquibase/lib/retrofit-${RETROFIT_VERSION}.jar \
+  "https://repo1.maven.org/maven2/com/squareup/retrofit2/retrofit/${RETROFIT_VERSION}/retrofit-${RETROFIT_VERSION}.jar"
+wget -O /liquibase/lib/converter-gson-${CONVERTOR_GSON_VERSION}.jar \
+  "https://repo1.maven.org/maven2/com/squareup/retrofit2/converter-gson/${CONVERTOR_GSON_VERSION}/converter-gson-${CONVERTOR_GSON_VERSION}.jar"
+wget -O /liquibase/lib/gson-${GSON_VERSION}.jar \
+  "https://repo1.maven.org/maven2/com/google/code/gson/gson/${GSON_VERSION}/gson-${GSON_VERSION}.jar"
+wget -O /liquibase/lib/kotlin-stdlib-${KOTLIN_STLIB_VERSION}.jar \
+  "https://repo1.maven.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/${KOTLIN_STLIB_VERSION}/kotlin-stdlib-${KOTLIN_STLIB_VERSION}.jar"

--- a/scripts/download-common.sh
+++ b/scripts/download-common.sh
@@ -10,6 +10,7 @@ RETROFIT_VERSION="3.0.0"
 CONVERTOR_GSON_VERSION="3.0.0"
 GSON_VERSION="2.13.1"
 KOTLIN_STLIB_VERSION="2.1.21"
+BOUNCY_CASTLE_VERSION="1.78.1"
 
 
 mkdir -p /liquibase/lib
@@ -43,3 +44,9 @@ wget -O /liquibase/lib/gson-${GSON_VERSION}.jar \
   "https://repo1.maven.org/maven2/com/google/code/gson/gson/${GSON_VERSION}/gson-${GSON_VERSION}.jar"
 wget -O /liquibase/lib/kotlin-stdlib-${KOTLIN_STLIB_VERSION}.jar \
   "https://repo1.maven.org/maven2/org/jetbrains/kotlin/kotlin-stdlib/${KOTLIN_STLIB_VERSION}/kotlin-stdlib-${KOTLIN_STLIB_VERSION}.jar"
+
+# Bouncy Castle
+wget -O /liquibase/lib/bcpkix-jdk18on-${BOUNCY_CASTLE_VERSION}.jar \
+  "https://repo1.maven.org/maven2/org/bouncycastle/bcpkix-jdk18on/${BOUNCY_CASTLE_VERSION}/bcpkix-jdk18on-${BOUNCY_CASTLE_VERSION}.jar"
+wget -O /liquibase/lib/bcprov-jdk18on-${BOUNCY_CASTLE_VERSION}.jar \
+  "https://repo1.maven.org/maven2/org/bouncycastle/bcprov-jdk18on/${BOUNCY_CASTLE_VERSION}/bcprov-jdk18on-${BOUNCY_CASTLE_VERSION}.jar"

--- a/scripts/download-mongo.sh
+++ b/scripts/download-mongo.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env sh
+set -eux
+
+MONGO_DRIVER_CORE_VERSION="5.0.0"
+MONGO_DRIVER_SYNC_VERSION="5.0.0"
+BSON_VERSION="5.0.0"
+LIQUIBASE_MONGODB_VERSION="4.24.0"
+SNAKEYAML_VERSION="2.2"
+
+
+mkdir -p /liquibase/lib
+
+# MongoDB-specific jars
+wget -O /liquibase/lib/mongodb-driver-core-${MONGO_DRIVER_CORE_VERSION}.jar \
+  "https://repo1.maven.org/maven2/org/mongodb/mongodb-driver-core/${MONGO_DRIVER_CORE_VERSION}/mongodb-driver-core-${MONGO_DRIVER_CORE_VERSION}.jar"
+wget -O /liquibase/lib/mongodb-driver-sync-${MONGO_DRIVER_SYNC_VERSION}.jar \
+  "https://repo1.maven.org/maven2/org/mongodb/mongodb-driver-sync/${MONGO_DRIVER_SYNC_VERSION}/mongodb-driver-sync-${MONGO_DRIVER_SYNC_VERSION}.jar"
+wget -O /liquibase/lib/bson-${BSON_VERSION}.jar \
+  "https://repo1.maven.org/maven2/org/mongodb/bson/${BSON_VERSION}/bson-${BSON_VERSION}.jar"
+wget -O /liquibase/lib/liquibase-mongodb-${LIQUIBASE_MONGODB_VERSION}.jar \
+  "https://repo1.maven.org/maven2/org/liquibase/ext/liquibase-mongodb/${LIQUIBASE_MONGODB_VERSION}/liquibase-mongodb-${LIQUIBASE_MONGODB_VERSION}.jar"
+wget -O /liquibase/lib/snakeyaml-${SNAKEYAML_VERSION}.jar \
+  "https://repo1.maven.org/maven2/org/yaml/snakeyaml/${SNAKEYAML_VERSION}/snakeyaml-${SNAKEYAML_VERSION}.jar"

--- a/scripts/download-spanner.sh
+++ b/scripts/download-spanner.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+set -eux
+
+LIQUIBASE_SPANNER_VERSION="4.30.0.1"
+
+mkdir -p /liquibase/lib
+
+# Spanner-specific jar
+wget -O /liquibase/lib/liquibase-spanner-${LIQUIBASE_SPANNER_VERSION}-all.jar \
+  "https://github.com/cloudspannerecosystem/liquibase-spanner/releases/download/${LIQUIBASE_SPANNER_VERSION}/liquibase-spanner-${LIQUIBASE_SPANNER_VERSION}-all.jar"


### PR DESCRIPTION
## Pull Request Summary

This PR introduces significant updates to the Docker setup for our database operations by upgrading the `dbops-ext` library to version 1.9.0 and implementing a new script-based approach for downloading necessary dependencies.

### Key Changes:
- **Library Upgrade**: The `dbops-ext` library has been upgraded to version 1.9.0, enhancing functionality and performance.
- **Script Integration**: Added new scripts (`download-common.sh`, `download-mongo.sh`, and `download-spanner.sh`) to streamline the downloading of required JAR files for MongoDB and Spanner, replacing the previous inline `wget` commands in the Dockerfiles. This modular approach improves maintainability and readability.

These changes collectively enhance the build process and ensure that the latest dependencies are easily integrated into our Docker images.