### PR TITLE
[feat]: [DBOPS-1328]: Add NOTICE to docker images

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,9 @@
+This library includes integration with software developed by Liquibase.
+Liquibase is licensed under the Apache License, Version 2.0 (the "License");
+you may not use this repo except in compliance with the License.
+You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and limitations under the License.

--- a/docker/Dockerfile.linux-mongo.amd64
+++ b/docker/Dockerfile.linux-mongo.amd64
@@ -26,6 +26,7 @@ COPY --from=alpine /lib/libcrypto.so.3 /lib/libcrypto.so.3
 
 COPY --from=alpine /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=alpine /liquibase/lib /liquibase/lib
+COPY NOTICE /liquibase/NOTICE
 
 # Copy the zstd binary from Alpine stage
 COPY --from=alpine /usr/bin/zstd /usr/bin/zstd

--- a/docker/Dockerfile.linux-mongo.arm64
+++ b/docker/Dockerfile.linux-mongo.arm64
@@ -25,6 +25,7 @@ COPY --from=alpine /lib/libcrypto.so.3 /lib/libcrypto.so.3
 
 COPY --from=alpine /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=alpine /liquibase/lib /liquibase/lib
+COPY NOTICE /liquibase/NOTICE
 
 # Copy the zstd binary from Alpine stage
 COPY --from=alpine /usr/bin/zstd /usr/bin/zstd

--- a/docker/Dockerfile.linux-spanner.amd64
+++ b/docker/Dockerfile.linux-spanner.amd64
@@ -25,6 +25,7 @@ COPY --from=alpine /lib/libcrypto.so.3 /lib/libcrypto.so.3
 
 COPY --from=alpine /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=alpine /liquibase/lib /liquibase/lib
+COPY NOTICE /liquibase/NOTICE
 
 # Copy the zstd binary from Alpine stage
 COPY --from=alpine /usr/bin/zstd /usr/bin/zstd

--- a/docker/Dockerfile.linux-spanner.arm64
+++ b/docker/Dockerfile.linux-spanner.arm64
@@ -25,6 +25,7 @@ COPY --from=alpine /lib/libcrypto.so.3 /lib/libcrypto.so.3
 
 COPY --from=alpine /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=alpine /liquibase/lib /liquibase/lib
+COPY NOTICE /liquibase/NOTICE
 
 # Copy the zstd binary from Alpine stage
 COPY --from=alpine /usr/bin/zstd /usr/bin/zstd

--- a/docker/Dockerfile.linux.amd64
+++ b/docker/Dockerfile.linux.amd64
@@ -27,5 +27,6 @@ COPY --from=alpine /usr/bin/jq /usr/bin/jq
 COPY --from=alpine /usr/lib/libonig.so.5 /usr/lib/libonig.so.5
 
 COPY --from=alpine /liquibase/lib /liquibase/lib
+COPY NOTICE /liquibase/NOTICE
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["--help"]

--- a/docker/Dockerfile.linux.arm64
+++ b/docker/Dockerfile.linux.arm64
@@ -25,5 +25,6 @@ COPY --from=alpine /usr/bin/zstd /usr/bin/zstd
 COPY --from=alpine /usr/bin/jq /usr/bin/jq
 COPY --from=alpine /usr/lib/libonig.so.5 /usr/lib/libonig.so.5
 COPY --from=alpine /liquibase/lib /liquibase/lib
+COPY NOTICE /liquibase/NOTICE
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["--help"]


### PR DESCRIPTION
Adding a NOTICE file to root of repository and copy it to path /liquibase/NOTICE in docker images